### PR TITLE
support to ignore comments eg. /*no*/  /*px*/

### DIFF
--- a/example/main-viewport.css
+++ b/example/main-viewport.css
@@ -1,10 +1,10 @@
 .class {
   margin: -3.125vw .5vh;
   padding: 5vmin 2.96875vw 1px;
-  border: 0.9375vw solid black;
+  border: 3px solid black; /*px*/
   border-bottom-width: 1px;
   font-size: 4.375vw;
-  line-height: 6.25vw;
+  line-height: 20px; /* no */
 }
 .class2 {
   border: 1px solid black;
@@ -16,6 +16,31 @@
   .class3 {
     font-size: 16px;
     line-height: 22px;
+  }
+}
+
+.class4::before {
+  content: '';
+  width: 3.125vw;
+  height: 3.125vw;
+  border: solid 2px #000; /*no*/
+}
+.ignore {
+  width: 3.125vw;
+}
+.ignore::after {
+  top: 3.125vw;
+}
+
+@keyframes move {
+  0% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(10px, -10px);
+  }
+  100% {
+    transform: translate(10px, -10px); /*no */
   }
 }
 

--- a/example/main-viewport.css
+++ b/example/main-viewport.css
@@ -1,10 +1,10 @@
 .class {
   margin: -3.125vw .5vh;
   padding: 5vmin 2.96875vw 1px;
-  border: 3px solid black; /*px*/
+  border: 3px solid black;
   border-bottom-width: 1px;
   font-size: 4.375vw;
-  line-height: 20px; /* no */
+  line-height: 20px;
 }
 .class2 {
   border: 1px solid black;
@@ -23,7 +23,7 @@
   content: '';
   width: 3.125vw;
   height: 3.125vw;
-  border: solid 2px #000; /*no*/
+  border: solid 2px #000;
 }
 .ignore {
   width: 3.125vw;

--- a/example/main.css
+++ b/example/main.css
@@ -1,10 +1,10 @@
 .class {
   margin: -10px .5vh;
   padding: 5vmin 9.5px 1px;
-  border: 3px solid black;
+  border: 3px solid black; /*px*/
   border-bottom-width: 1px;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 20px; /* no */
 }
 .class2 {
   border: 1px solid black;
@@ -16,6 +16,31 @@
   .class3 {
     font-size: 16px;
     line-height: 22px;
+  }
+}
+
+.class4::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border: solid 2px #000; /*no*/
+}
+.ignore {
+  width: 10px;
+}
+.ignore::after {
+  top: 10px;
+}
+
+@keyframes move {
+  0% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(10px, -10px);
+  }
+  100% {
+    transform: translate(10px, -10px); /*no */
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -84,11 +84,13 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
           size = opts.viewportWidth;
         }
 
-        let nodes = decl.parent.nodes;
-        let indexes = decl.parent.indexes['1'];
-        let next = nodes[indexes + 1];
+        var nodes = decl.parent.nodes;
+        var indexes = decl.parent.indexes['1'];
+        var next = nodes[indexes + 1];
         // next declaration is comment and comment text is no or px
         if (next && next.type === 'comment' && (next.text === 'no' || next.text === 'px')) {
+          // remove comment
+          nodes.splice(indexes + 1, 1);
           return;
         }
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,15 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
           unit = getUnit(decl.prop, opts);
           size = opts.viewportWidth;
         }
-        
+
+        let nodes = decl.parent.nodes;
+        let indexes = decl.parent.indexes['1'];
+        let next = nodes[indexes + 1];
+        // next declaration is comment and comment text is no or px
+        if (next && next.type === 'comment' && (next.text === 'no' || next.text === 'px')) {
+          return;
+        }
+
         var value = decl.value.replace(pxRegex, createPxReplace(opts, unit, size));
         
         if (declarationExists(decl.parent, decl.prop, value)) return;

--- a/spec/px-to-viewport.spec.js
+++ b/spec/px-to-viewport.spec.js
@@ -457,5 +457,23 @@ describe('landscape', function() {
     var expected = '.rule { font-size: 15vw }';
 
     expect(processed).toBe(expected);
+  });
+
+  it('should ignore comments with no', function() {
+    var css = '.rule { font-size: 15px; height: 100px; /*no*/ }';
+    var expected = '.rule { font-size: 4.6875vw; height: 100px; }';
+
+    var processed = postcss(pxToViewport()).process(css).css;
+
+    expect(processed).toBe(expected);
+  });
+
+  it('should ignore comments with px', function() {
+    var css = '.rule { font-size: 15px; height: 100px; /*px*/ }';
+    var expected = '.rule { font-size: 4.6875vw; height: 100px; }';
+
+    var processed = postcss(pxToViewport()).process(css).css;
+
+    expect(processed).toBe(expected);
   })
 });


### PR DESCRIPTION
Sometimes selectorBlackList is not easy to use. 

example:

```css
// before - add selectorBlackList ['ignore']
.box {
    width: 10px;
    height: 10px;
}
.box.ignore {
    border: solid 1px #ddd;
}

// now - with comments
.box {
    width: 10px;
    height: 10px;
    border: solid 1px #ddd; /*no*/
}
```