### PR TITLE
• fix: 修复windowns环境下path为右斜杠时，exclude 正则匹配失效的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
     css.walkRules(function (rule) {
       // Add exclude option to ignore some files like 'node_modules'
       var file = rule.source && rule.source.input.file;
-
+      // fix in window, path use '\'
+      file = file.replace(/\\/g, '/');
       if (opts.include && file) {
         if (Object.prototype.toString.call(opts.include) === '[object RegExp]') {
           if (!opts.include.test(file)) return;


### PR DESCRIPTION
修复windowns环境下path为右斜杠时，exclude 正则匹配失效的问题