### PR TITLE
Supported multi options

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,20 @@ module.exports = {
 }
 ```
 
+or use multi options
+```js
+module.exports = {
+  plugins: {
+    // ...
+    'postcss-px-to-viewport': [{
+      // options 1
+    },{
+      // options 2
+    }]
+  }
+}
+```
+
 #### Use with gulp-postcss
 
 add to your `gulpfile.js`:

--- a/exampleWithMultiOptions/index.js
+++ b/exampleWithMultiOptions/index.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var fs = require('fs');
+var postcss = require('postcss');
+var pxToViewport = require('..');
+var css = fs.readFileSync('main.css', 'utf8');
+
+var multiOptions = [{
+  unitToConvert: 'px'
+},{
+  unitToConvert: 'rem'
+}]
+
+var processedCss = postcss(pxToViewport(multiOptions)).process(css).css;
+
+fs.writeFile('main-viewport.css', processedCss, function (err) {
+  if (err) {
+    throw err;
+  }
+  console.log('File with viewport units written.');
+});

--- a/exampleWithMultiOptions/main-viewport.css
+++ b/exampleWithMultiOptions/main-viewport.css
@@ -1,0 +1,54 @@
+.class {
+  margin: -3.125vw .5vh;
+  padding: 5vmin 2.96875vw 1rem;
+  border: 0.9375vw solid black;
+  border-bottom-width: 1px;
+  font-size: 4.375vw;
+  line-height: 6.25vw;
+}
+.class2 {
+  border: 1px solid black;
+  margin-bottom: 1px;
+  font-size: 6.25vw;
+  line-height: 9.375vw;
+}
+@media (min-width: 750px) {
+  .class3 {
+    font-size: 16px;
+    line-height: 22rem;
+  }
+}
+
+.class4-ignore::before {
+  content: '';
+  width: 10px;
+  padding: 3.125vw;
+  height: 10rem;
+  border: solid 2px #000;
+}
+.class5-bad-ignore {
+  /* px-to-viewport-ignore */
+  width: 3.125vw;
+  /* px-to-viewport-ignore */
+  height: 3.125vw;
+  /* px-to-viewport-ignore-next */
+}
+
+@keyframes move {
+  0% {
+    transform: translate(0, 0);
+  }
+  /* px-to-viewport-ignore-next */
+  50% {
+    transform: translate(10px, -10px);
+  }
+  100% {
+    transform: translate(10px, -10px); /* px-to-viewport-ignore */
+  }
+}
+
+/*
+.class {
+    font-size: 16px;
+}
+*/

--- a/exampleWithMultiOptions/main.css
+++ b/exampleWithMultiOptions/main.css
@@ -1,0 +1,55 @@
+.class {
+  margin: -10px .5vh;
+  padding: 5vmin 9.5rem 1rem;
+  border: 3px solid black;
+  border-bottom-width: 1px;
+  font-size: 14px;
+  line-height: 20px;
+}
+.class2 {
+  border: 1px solid black;
+  margin-bottom: 1px;
+  font-size: 20rem;
+  line-height: 30px;
+}
+@media (min-width: 750px) {
+  .class3 {
+    font-size: 16px;
+    line-height: 22rem;
+  }
+}
+
+.class4-ignore::before {
+  content: '';
+  /* px-to-viewport-ignore-next */
+  width: 10px;
+  padding: 10px;
+  height: 10rem; /* px-to-viewport-ignore */
+  border: solid 2px #000; /* px-to-viewport-ignore */
+}
+.class5-bad-ignore {
+  /* px-to-viewport-ignore */
+  width: 10rem;
+  /* px-to-viewport-ignore */
+  height: 10px;
+  /* px-to-viewport-ignore-next */
+}
+
+@keyframes move {
+  0% {
+    transform: translate(0, 0);
+  }
+  /* px-to-viewport-ignore-next */
+  50% {
+    transform: translate(10px, -10px);
+  }
+  100% {
+    transform: translate(10px, -10px); /* px-to-viewport-ignore */
+  }
+}
+
+/*
+.class {
+    font-size: 16px;
+}
+*/

--- a/spec/px-to-viewport-multi-options.spec.js
+++ b/spec/px-to-viewport-multi-options.spec.js
@@ -1,0 +1,47 @@
+// To run tests, run these commands from the project root:
+// 1. `npm install`
+// 2. `npm test`
+
+/* global describe, it, expect */
+
+var postcss = require('postcss');
+var pxToViewport = require('..');
+var basicCSS = '.rule { font-size: 15px; padding: 0rem 0px 15rem 15px }';
+
+var multiOptions = [{
+  unitToConvert: 'px'
+},{
+  unitToConvert: 'rem'
+}]
+
+describe('dose multi options wark', function() {
+  it('px-to-viewport', function () {
+    var input = 'h1 { margin: 0 0 20rem; font-size: 32px; line-height: 2; letter-spacing: 1px; }';
+    var output = 'h1 { margin: 0 0 6.25vw; font-size: 10vw; line-height: 2; letter-spacing: 1px; }';
+    var processed = postcss(pxToViewport(multiOptions)).process(input).css;
+
+    expect(processed).toBe(output);
+  });
+
+  it('should not replace values in `url()`', function () {
+    var rules = '.rule { background: url(16px.jpg); font-size: 16rem; }';
+    var expected = '.rule { background: url(16px.jpg); font-size: 5vw; }';
+    var processed = postcss(pxToViewport(multiOptions)).process(rules).css;
+
+    expect(processed).toBe(expected);
+  });
+
+  it('should ignore non px values by default', function () {
+    var expected = '.rule { font-size: 2em }';
+    var processed = postcss(pxToViewport(multiOptions)).process(expected).css;
+
+    expect(processed).toBe(expected);
+  });
+
+  it('should should replace using 320px by default', function() {
+    var expected = '.rule { font-size: 4.6875vw; padding: 0rem 0px 4.6875vw 4.6875vw }';
+    var processed = postcss(pxToViewport(multiOptions)).process(basicCSS).css;
+
+    expect(processed).toBe(expected);
+  });
+})


### PR DESCRIPTION
When we have **two or more** units in our CSS files, they need to be all converted to `vw`.

And it has no performance impact on the original function.

using example:
```js
module.exports = {
  plugins: {
    // ...
    'postcss-px-to-viewport': [{
      // options 1
    },{
      // options 2
    }]
  }
}
```

