### PR TITLE
feature: support multi units 支持设置多个自定义单位或规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log*
 node_modules
 .idea
 yarn.lock
+coverage

--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ Default Options:
 
 > `exclude` and `include` can be set together, and the intersection of the two rules will be taken.
 
+Or you can set up multiple option groups like this:
+
+```js
+[
+  {
+    unitToConvert: 'rpx',
+    viewportWidth: 750,
+    viewportUnit: 'vw',
+    minPixelValue: 0
+  }, {
+    unitToConvert: 'dpx',
+    viewportWidth: 1920,
+    viewportUnit: 'vw',
+    minPixelValue: 0
+  }
+]
+```
+
+Passing in an empty array (`[]`) will not convert any units.
+
+Each option group will be merged with the default settings, so you can easily define multiple custom units and conversion rules.
+
+> If the `unitToConvert` in multiple sets of settings is the same, the last declared one may override the previously declared.
+
 #### Ignoring
 
 You can use special comments for ignore conversion of single lines:

--- a/README_CN.md
+++ b/README_CN.md
@@ -135,13 +135,35 @@ $ yarn add -D postcss-px-to-viewport
 
 > `exclude`和`include`是可以一起设置的，将取两者规则的交集。
 
-#### Ignoring (需要翻译帮助。)
+你也可以同时设置多组单位转换规则:
 
-You can use special comments for ignore conversion of single lines:
-- `/* px-to-viewport-ignore-next */` — on a separate line, prevents conversion on the next line.
-- `/* px-to-viewport-ignore */` — after the property on the right, prevents conversion on the same line.
+```js
+[
+  {
+    unitToConvert: 'rpx',
+    viewportWidth: 750,
+    viewportUnit: 'vw',
+    minPixelValue: 0
+  }, {
+    unitToConvert: 'dpx',
+    viewportWidth: 1920,
+    viewportUnit: 'vw',
+    minPixelValue: 0
+  }
+]
+```
 
-Example:
+传入空数组（`[]`）作为参数时，不会转化任何单位。数组中的所有设置都会和默认设置合并，这样就可以轻松声明多个自定义单位或者转化规则。
+
+> 如果多个设置中的 `unitToConvert` 相同，通常只有最后一个设置会生效。 
+
+#### Ignoring
+
+你可以使用如下的特殊注释来忽略单行的转换：
+- `/* px-to-viewport-ignore-next */` — 声明在某行之上，会忽略下一行的转换。
+- `/* px-to-viewport-ignore */` — 声明在某属性的右侧，会忽略本行的转换。
+
+例子：
 ```css
 /* example input: */
 .class {
@@ -161,7 +183,7 @@ Example:
 }
 ```
 
-There are several more reasons why your pixels may not convert, the following options may affect this:
+以下配置项同样有能力阻止单位转换:
 `propList`, `selectorBlackList`, `minPixelValue`, `mediaQuery`, `exclude`, `include`.
 
 #### 使用PostCss配置文件时

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var postcss = require('postcss');
-var objectAssign = require('object-assign');
-var { createPropListMatcher } = require('./src/prop-list-matcher');
-var { getUnitRegexp } = require('./src/pixel-unit-regexp');
+const postcss = require('postcss');
+const objectAssign = require('object-assign');
+const { createPropListMatcher } = require('./src/prop-list-matcher');
+const { getUnitRegexp } = require('./src/pixel-unit-regexp');
 
-var defaults = {
+const defaults = {
   unitToConvert: 'px',
   viewportWidth: 320,
   viewportHeight: 568, // not now used; TODO: need for different units and math for different properties
@@ -22,61 +22,46 @@ var defaults = {
   landscapeWidth: 568
 };
 
-var ignoreNextComment = 'px-to-viewport-ignore-next';
-var ignorePrevComment = 'px-to-viewport-ignore';
+const ignoreNextComment = 'px-to-viewport-ignore-next';
+const ignorePrevComment = 'px-to-viewport-ignore';
 
-module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
-  var opts = objectAssign({}, defaults, options);
-
-  checkRegExpOrArray(opts, 'exclude');
-  checkRegExpOrArray(opts, 'include');
-
-  var pxRegex = getUnitRegexp(opts.unitToConvert);
-  var satisfyPropList = createPropListMatcher(opts.propList);
-  var landscapeRules = [];
-
-  return function (css, result) {
-    css.walkRules(function (rule) {
+module.exports = postcss.plugin('postcss-px-to-viewport-with-array', function (pluginOptions) {
+  const arrayedOptions = isArray(pluginOptions) ? pluginOptions : [pluginOptions];
+  const landscapeRules = [];
+  const walkRuleFunctions = [];
+  arrayedOptions.forEach(customizedOptions => {
+    const options = objectAssign({}, defaults, customizedOptions);
+    if (options.exclude && !isRegExpOrRegExpArray(options.exclude)) {
+      throw new Error('options.exclude should be RegExp or Array of RegExp.');
+    }
+    if (options.include && !isRegExpOrRegExpArray(options.include)) {
+      throw new Error('options.include should be RegExp or Array of RegExp.');
+    }
+    const pxRegExp = getUnitRegexp(options.unitToConvert);
+    const satisfyPropList = createPropListMatcher(options.propList);
+    const walkRuleFunction = (rule) => {
       // Add exclude option to ignore some files like 'node_modules'
-      var file = rule.source && rule.source.input.file;
+      const file = rule.source && rule.source.input.file;
 
-      if (opts.include && file) {
-        if (Object.prototype.toString.call(opts.include) === '[object RegExp]') {
-          if (!opts.include.test(file)) return;
-        } else if (Object.prototype.toString.call(opts.include) === '[object Array]') {
-          var flag = false;
-          for (var i = 0; i < opts.include.length; i++) {
-            if (opts.include[i].test(file)) {
-              flag = true;
-              break;
-            }
-          }
-          if (!flag) return;
-        }
-      }
+      if (!shouldFileInclude(options.include, file)) return;
+      if (shouldFileExclude(options.exclude, file)) return;
+      if (isBlacklistedSelector(options.selectorBlackList, rule.selector)) return;
 
-      if (opts.exclude && file) {
-        if (Object.prototype.toString.call(opts.exclude) === '[object RegExp]') {
-          if (opts.exclude.test(file)) return;
-        } else if (Object.prototype.toString.call(opts.exclude) === '[object Array]') {
-          for (var i = 0; i < opts.exclude.length; i++) {
-            if (opts.exclude[i].test(file)) return;
-          }
-        }
-      }
-
-      if (blacklistedSelector(opts.selectorBlackList, rule.selector)) return;
-
-      if (opts.landscape && !rule.parent.params) {
-        var landscapeRule = rule.clone().removeAll();
+      if (options.landscape && !rule.parent.params) {
+        const landscapeRule = rule.clone().removeAll();
 
         rule.walkDecls(function(decl) {
-          if (decl.value.indexOf(opts.unitToConvert) === -1) return;
+          if (decl.value.indexOf(options.unitToConvert) === -1) return;
           if (!satisfyPropList(decl.prop)) return;
 
-          landscapeRule.append(decl.clone({
-            value: decl.value.replace(pxRegex, createPxReplace(opts, opts.landscapeUnit, opts.landscapeWidth))
-          }));
+          landscapeRule.append(
+            decl.clone({
+              value: decl.value.replace(
+                pxRegExp,
+                createPxReplace(options, options.landscapeUnit, options.landscapeWidth)
+              ),
+            })
+          );
         });
 
         if (landscapeRule.nodes.length > 0) {
@@ -84,20 +69,20 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
         }
       }
 
-      if (!validateParams(rule.parent.params, opts.mediaQuery)) return;
+      if (!isValidateParams(rule.parent.params, options.mediaQuery)) return;
 
-      rule.walkDecls(function(decl, i) {
-        if (decl.value.indexOf(opts.unitToConvert) === -1) return;
+      rule.walkDecls((decl, i) => {
+        if (decl.value.indexOf(options.unitToConvert) === -1) return;
         if (!satisfyPropList(decl.prop)) return;
 
-        var prev = decl.prev();
+        const prev = decl.prev();
         // prev declaration is ignore conversion comment at same line
         if (prev && prev.type === 'comment' && prev.text === ignoreNextComment) {
           // remove comment
           prev.remove();
           return;
         }
-        var next = decl.next();
+        const next = decl.next();
         // next declaration is ignore conversion comment at same line
         if (next && next.type === 'comment' && next.text === ignorePrevComment) {
           if (/\n/.test(next.raws.before)) {
@@ -109,83 +94,101 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
           }
         }
 
-        var unit;
-        var size;
-        var params = rule.parent.params;
-
-        if (opts.landscape && params && params.indexOf('landscape') !== -1) {
-          unit = opts.landscapeUnit;
-          size = opts.landscapeWidth;
+        let unit;
+        let size;
+        const params = rule.parent.params;
+        if (options.landscape && params && params.indexOf('landscape') !== -1) {
+          unit = options.landscapeUnit;
+          size = options.landscapeWidth;
         } else {
-          unit = getUnit(decl.prop, opts);
-          size = opts.viewportWidth;
+          unit = getUnit(decl.prop, options);
+          size = options.viewportWidth;
         }
 
-        var value = decl.value.replace(pxRegex, createPxReplace(opts, unit, size));
+        const value = decl.value.replace(pxRegExp, createPxReplace(options, unit, size));
 
-        if (declarationExists(decl.parent, decl.prop, value)) return;
+        if (isDeclarationExists(decl.parent, decl.prop, value)) return;
 
-        if (opts.replace) {
+        if (options.replace) {
           decl.value = value;
         } else {
           decl.parent.insertAfter(i, decl.clone({ value: value }));
         }
       });
+    };
+    walkRuleFunctions.push(walkRuleFunction);
+  });
+
+  return (css) => {
+    walkRuleFunctions.forEach(walkFunction => {
+      css.walkRules(walkFunction);
     });
-
-    if (landscapeRules.length > 0) {
-      var landscapeRoot = new postcss.atRule({ params: '(orientation: landscape)', name: 'media' });
-
-      landscapeRules.forEach(function(rule) {
-        landscapeRoot.append(rule);
-      });
-      css.append(landscapeRoot);
-    }
+    if (landscapeRules.length === 0) return;
+    const landscapeRoot = new postcss.atRule({ params: '(orientation: landscape)', name: 'media' });
+    landscapeRoot.append([...landscapeRules]);
+    css.append(landscapeRoot);
   };
 });
 
-function getUnit(prop, opts) {
-  return prop.indexOf('font') === -1 ? opts.viewportUnit : opts.fontViewportUnit;
+function isRegExp(value) {
+  return Object.prototype.toString.call(value) === '[object RegExp]';
 }
 
-function createPxReplace(opts, viewportUnit, viewportSize) {
+function isArray(value) {
+  return Object.prototype.toString.call(value) === '[object Array]';
+}
+
+function shouldFileInclude(option, file) {
+  if (!option || !file) {
+    return true;
+  }
+  return isFileMatchOption(option, file);
+}
+
+function shouldFileExclude(option, file) {
+  if (!option || !file) {
+    return false;
+  }
+  return isFileMatchOption(option, file);
+}
+
+function isFileMatchOption(option, file) {
+  if (isRegExp(option)) {
+    return option.test(file);
+  } else if (isArray(option)) {
+    return option.some((item) => { return item.test(file); });
+  }
+}
+
+function getUnit(prop, options) {
+  return prop.indexOf('font') === -1 ? options.viewportUnit : options.fontViewportUnit;
+}
+
+function createPxReplace(options, viewportUnit, viewportSize) {
   return function (m, $1) {
     if (!$1) return m;
     var pixels = parseFloat($1);
-    if (pixels <= opts.minPixelValue) return m;
-    var parsedVal = toFixed((pixels / viewportSize * 100), opts.unitPrecision);
+    if (pixels <= options.minPixelValue) return m;
+    var parsedVal = toFixed((pixels / viewportSize * 100), options.unitPrecision);
     return parsedVal === 0 ? '0' : parsedVal + viewportUnit;
   };
 }
 
-function error(decl, message) {
-  throw decl.error(message, { plugin: 'postcss-px-to-viewport' });
-}
-
-function checkRegExpOrArray(options, optionName) {
-  var option = options[optionName];
-  if (!option) return;
-  if (Object.prototype.toString.call(option) === '[object RegExp]') return;
-  if (Object.prototype.toString.call(option) === '[object Array]') {
-    var bad = false;
-    for (var i = 0; i < option.length; i++) {
-      if (Object.prototype.toString.call(option[i]) !== '[object RegExp]') {
-        bad = true;
-        break;
-      }
-    }
-    if (!bad) return;
+function isRegExpOrRegExpArray(option) {
+  if (isRegExp(option)) return true;
+  if (isArray(option)) {
+    return option.every((item) => { return isRegExp(item); });
   }
-  throw new Error('options.' + optionName + ' should be RegExp or Array of RegExp.');
+  return false;
 }
 
 function toFixed(number, precision) {
-  var multiplier = Math.pow(10, precision + 1),
-    wholeNumber = Math.floor(number * multiplier);
+  const multiplier = Math.pow(10, precision + 1);
+  const wholeNumber = Math.floor(number * multiplier);
   return Math.round(wholeNumber / 10) * 10 / multiplier;
 }
 
-function blacklistedSelector(blacklist, selector) {
+function isBlacklistedSelector(blacklist, selector) {
   if (typeof selector !== 'string') return;
   return blacklist.some(function (regex) {
     if (typeof regex === 'string') return selector.indexOf(regex) !== -1;
@@ -193,12 +196,12 @@ function blacklistedSelector(blacklist, selector) {
   });
 }
 
-function declarationExists(decls, prop, value) {
+function isDeclarationExists(decls, prop, value) {
   return decls.some(function (decl) {
-      return (decl.prop === prop && decl.value === value);
+    return (decl.prop === prop && decl.value === value);
   });
 }
 
-function validateParams(params, mediaQuery) {
+function isValidateParams(params, mediaQuery) {
   return !params || (params && mediaQuery);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "postcss-plugin"
   ],
   "scripts": {
-    "test": "jest spec/*.spec.js"
+    "test": "jest spec/*.spec.js",
+    "test-with-coverage": "jest --coverage spec/*.spec.js"
   },
   "dependencies": {
     "object-assign": ">=4.0.1"

--- a/spec/px-to-viewport.spec.js
+++ b/spec/px-to-viewport.spec.js
@@ -324,6 +324,19 @@ describe('exclude', function () {
 
     expect(processed).toBe(covered);
   });
+
+  it('when using incorrect type at the time, should throw an error.', function () {
+    var options = {
+      exclude: 'incorrectTypeAsString'
+    };
+    var processedFunction = () => {
+      postcss(pxToViewport(options)).process(rules, {
+        from: '/example/main.css'
+      }).css;
+    }
+
+    expect(processedFunction).toThrowError('options.exclude should be RegExp or Array of RegExp.');
+  });
 });
 
 describe('include', function () {
@@ -371,6 +384,19 @@ describe('include', function () {
     }).css;
 
     expect(processed).toBe(covered);
+  });
+
+  it('when using incorrect type at the time, should throw an error.', function () {
+    var options = {
+      include: 'incorrectTypeAsString'
+    };
+    var processedFunction = () => {
+      postcss(pxToViewport(options)).process(rules, {
+        from: '/example/main.css'
+      }).css;
+    }
+
+    expect(processedFunction).toThrowError('options.include should be RegExp or Array of RegExp.');
   });
 });
 
@@ -634,5 +660,46 @@ describe('/* px-to-viewport-ignore */ & /* px-to-viewport-ignore-next */', funct
     var processed = postcss(pxToViewport()).process(css).css;
 
     expect(processed).toBe(expected);
+  });
+});
+
+describe('multiple-option-groups', function() {
+  it('should work on the readme example', function () {
+    var input = 'mobile h1 { margin: 0 0 20rpx; font-size: 32rpx; line-height: 2; letter-spacing: 1rpx; } desktop h1 { margin: 0 0 20dpx; font-size: 32dpx; line-height: 2; letter-spacing: 1dpx; }';
+    var output = 'mobile h1 { margin: 0 0 2.66667vw; font-size: 4.26667vw; line-height: 2; letter-spacing: 0.13333vw; } desktop h1 { margin: 0 0 1.04167vw; font-size: 1.66667vw; line-height: 2; letter-spacing: 0.05208vw; }';
+    var options = [
+      {
+        unitToConvert: 'rpx',
+        viewportWidth: 750,
+        viewportUnit: 'vw',
+        minPixelValue: 0
+      }, {
+        unitToConvert: 'dpx',
+        viewportWidth: 1920,
+        viewportUnit: 'vw',
+        minPixelValue: 0
+      }
+    ];
+    var processed = postcss(pxToViewport(options)).process(input).css;
+
+    expect(processed).toBe(output);
+  });
+
+  it('should not work with empty option array', function () {
+    var input = 'h1 { margin: 0 0 20px; font-size: 32px; line-height: 2; letter-spacing: 1px; }';
+    var output = 'h1 { margin: 0 0 20px; font-size: 32px; line-height: 2; letter-spacing: 1px; }';
+    var options = [];
+    var processed = postcss(pxToViewport(options)).process(input).css;
+
+    expect(processed).toBe(output);
+  });
+
+  it('should work with empty option object with default settings', function () {
+    var input = 'h1 { margin: 0 0 20px; font-size: 32px; line-height: 2; letter-spacing: 1px; }';
+    var output = 'h1 { margin: 0 0 6.25vw; font-size: 10vw; line-height: 2; letter-spacing: 1px; }';
+    var options = [{}];
+    var processed = postcss(pxToViewport(options)).process(input).css;
+
+    expect(processed).toBe(output);
   });
 });


### PR DESCRIPTION
Support mulit multipleunits like:
支持设置多个自定义单位：

```js
[
  {
    unitToConvert: 'rpx',
    viewportWidth: 750,
    viewportUnit: 'vw',
    minPixelValue: 0
  }, {
    unitToConvert: 'dpx',
    viewportWidth: 1920,
    viewportUnit: 'vw',
    minPixelValue: 0
  }
]
```
At the same time,  added tests and documents related to this part of the function.
同时添加了这部分功能相关的测试和文档。


### Test 

![image](https://user-images.githubusercontent.com/7018688/100974507-50ecab00-3577-11eb-98eb-f982a31ec821.png)

Environment 测试环境：

- Windows 10 1909 WSL v1 with Ubuntu-18.04 Node v8.17.0, v10.23.0, v12.14.0 and v14.15.1
- Ubuntu 18.04 Node v10.15.3
- MacOS 10.15.7 Node v10.15.3

### Issues

#75 
