### PR TITLE
Update to postcss8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# postcss-px-to-viewport
+# postcss8-px-to-viewport
+
+This is a fork of [postcss-px-to-viewport](https://github.com/evrone/postcss-px-to-viewport), I migrate it to PostCSS8.
+
+## postcss-px-to-viewport
+
 [![NPM version](https://badge.fury.io/js/postcss-px-to-viewport.svg)](http://badge.fury.io/js/postcss-px-to-viewport)
 
 English | [中文](README_CN.md) 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,8 @@
-# postcss-px-to-viewport
+# postcss8-px-to-viewport
+
+此项目是 (postcss-px-to-viewport)[https://github.com/evrone/postcss-px-to-viewport] 的一个 fork，我将其迁移至了 PostCSS8 版本。
+
+## postcss-px-to-viewport
 [![NPM version](https://badge.fury.io/js/postcss-px-to-viewport.svg)](http://badge.fury.io/js/postcss-px-to-viewport)
 
 [English](README.md) | 中文

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var postcss = require('postcss');
 var objectAssign = require('object-assign');
 var { createPropListMatcher } = require('./src/prop-list-matcher');
 var { getUnitRegexp } = require('./src/pixel-unit-regexp');
@@ -25,7 +24,7 @@ var defaults = {
 var ignoreNextComment = 'px-to-viewport-ignore-next';
 var ignorePrevComment = 'px-to-viewport-ignore';
 
-module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
+module.exports = function (options) {
   var opts = objectAssign({}, defaults, options);
 
   checkRegExpOrArray(opts, 'exclude');
@@ -35,114 +34,119 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
   var satisfyPropList = createPropListMatcher(opts.propList);
   var landscapeRules = [];
 
-  return function (css, result) {
-    css.walkRules(function (rule) {
-      // Add exclude option to ignore some files like 'node_modules'
-      var file = rule.source && rule.source.input.file;
+  return {
+    postcssPlugin: 'postcss-px-to-viewport',
+    Once (css, { result, AtRule }) {
+      css.walkRules(function (rule) {
+          // Add exclude option to ignore some files like 'node_modules'
+          var file = rule.source && rule.source.input.file;
 
-      if (opts.include && file) {
-        if (Object.prototype.toString.call(opts.include) === '[object RegExp]') {
-          if (!opts.include.test(file)) return;
-        } else if (Object.prototype.toString.call(opts.include) === '[object Array]') {
-          var flag = false;
-          for (var i = 0; i < opts.include.length; i++) {
-            if (opts.include[i].test(file)) {
-              flag = true;
-              break;
+          if (opts.include && file) {
+            if (Object.prototype.toString.call(opts.include) === '[object RegExp]') {
+              if (!opts.include.test(file)) return;
+            } else if (Object.prototype.toString.call(opts.include) === '[object Array]') {
+              var flag = false;
+              for (var i = 0; i < opts.include.length; i++) {
+                if (opts.include[i].test(file)) {
+                  flag = true;
+                  break;
+                }
+              }
+              if (!flag) return;
             }
           }
-          if (!flag) return;
-        }
-      }
-
-      if (opts.exclude && file) {
-        if (Object.prototype.toString.call(opts.exclude) === '[object RegExp]') {
-          if (opts.exclude.test(file)) return;
-        } else if (Object.prototype.toString.call(opts.exclude) === '[object Array]') {
-          for (var i = 0; i < opts.exclude.length; i++) {
-            if (opts.exclude[i].test(file)) return;
+    
+          if (opts.exclude && file) {
+            if (Object.prototype.toString.call(opts.exclude) === '[object RegExp]') {
+              if (opts.exclude.test(file)) return;
+            } else if (Object.prototype.toString.call(opts.exclude) === '[object Array]') {
+              for (var i = 0; i < opts.exclude.length; i++) {
+                if (opts.exclude[i].test(file)) return;
+              }
+            }
           }
+    
+          if (blacklistedSelector(opts.selectorBlackList, rule.selector)) return;
+
+          if (opts.landscape && !rule.parent.params) {
+            var landscapeRule = rule.clone().removeAll();
+    
+            rule.walkDecls(function(decl) {
+              if (decl.value.indexOf(opts.unitToConvert) === -1) return;
+              if (!satisfyPropList(decl.prop)) return;
+              landscapeRule.append(decl.clone({
+                value: decl.value.replace(pxRegex, createPxReplace(opts, opts.landscapeUnit, opts.landscapeWidth))
+              }));
+            });
+    
+            if (landscapeRule.nodes.length > 0) {
+              landscapeRules.push(landscapeRule);
+            }
+          }
+    
+          if (!validateParams(rule.parent.params, opts.mediaQuery)) return;
+    
+          rule.walkDecls(function(decl, i) {
+            if (decl.value.indexOf(opts.unitToConvert) === -1) return;
+            if (!satisfyPropList(decl.prop)) return;
+    
+            var prev = decl.prev();
+            // prev declaration is ignore conversion comment at same line
+            if (prev && prev.type === 'comment' && prev.text === ignoreNextComment) {
+              // remove comment
+              prev.remove();
+              return;
+            }
+            var next = decl.next();
+            // next declaration is ignore conversion comment at same line
+            if (next && next.type === 'comment' && next.text === ignorePrevComment) {
+              if (/\n/.test(next.raws.before)) {
+                result.warn('Unexpected comment /* ' + ignorePrevComment + ' */ must be after declaration at same line.', { node: next });
+              } else {
+                // remove comment
+                next.remove();
+                return;
+              }
+            }
+    
+            var unit;
+            var size;
+            var params = rule.parent.params;
+    
+            if (opts.landscape && params && params.indexOf('landscape') !== -1) {
+              unit = opts.landscapeUnit;
+              size = opts.landscapeWidth;
+            } else {
+              unit = getUnit(decl.prop, opts);
+              size = opts.viewportWidth;
+            }
+    
+            var value = decl.value.replace(pxRegex, createPxReplace(opts, unit, size));
+    
+            if (declarationExists(decl.parent, decl.prop, value)) return;
+    
+            if (opts.replace) {
+              decl.value = value;
+            } else {
+              decl.parent.insertAfter(i, decl.clone({ value: value }));
+            }
+          });
         }
-      }
+      );
 
-      if (blacklistedSelector(opts.selectorBlackList, rule.selector)) return;
-
-      if (opts.landscape && !rule.parent.params) {
-        var landscapeRule = rule.clone().removeAll();
-
-        rule.walkDecls(function(decl) {
-          if (decl.value.indexOf(opts.unitToConvert) === -1) return;
-          if (!satisfyPropList(decl.prop)) return;
-
-          landscapeRule.append(decl.clone({
-            value: decl.value.replace(pxRegex, createPxReplace(opts, opts.landscapeUnit, opts.landscapeWidth))
-          }));
+      if (landscapeRules.length > 0) {
+        var landscapeRoot = new AtRule({ params: '(orientation: landscape)', name: 'media' });
+  
+        landscapeRules.forEach(function(rule) {
+          landscapeRoot.append(rule);
         });
-
-        if (landscapeRule.nodes.length > 0) {
-          landscapeRules.push(landscapeRule);
-        }
+        css.append(landscapeRoot);
       }
-
-      if (!validateParams(rule.parent.params, opts.mediaQuery)) return;
-
-      rule.walkDecls(function(decl, i) {
-        if (decl.value.indexOf(opts.unitToConvert) === -1) return;
-        if (!satisfyPropList(decl.prop)) return;
-
-        var prev = decl.prev();
-        // prev declaration is ignore conversion comment at same line
-        if (prev && prev.type === 'comment' && prev.text === ignoreNextComment) {
-          // remove comment
-          prev.remove();
-          return;
-        }
-        var next = decl.next();
-        // next declaration is ignore conversion comment at same line
-        if (next && next.type === 'comment' && next.text === ignorePrevComment) {
-          if (/\n/.test(next.raws.before)) {
-            result.warn('Unexpected comment /* ' + ignorePrevComment + ' */ must be after declaration at same line.', { node: next });
-          } else {
-            // remove comment
-            next.remove();
-            return;
-          }
-        }
-
-        var unit;
-        var size;
-        var params = rule.parent.params;
-
-        if (opts.landscape && params && params.indexOf('landscape') !== -1) {
-          unit = opts.landscapeUnit;
-          size = opts.landscapeWidth;
-        } else {
-          unit = getUnit(decl.prop, opts);
-          size = opts.viewportWidth;
-        }
-
-        var value = decl.value.replace(pxRegex, createPxReplace(opts, unit, size));
-
-        if (declarationExists(decl.parent, decl.prop, value)) return;
-
-        if (opts.replace) {
-          decl.value = value;
-        } else {
-          decl.parent.insertAfter(i, decl.clone({ value: value }));
-        }
-      });
-    });
-
-    if (landscapeRules.length > 0) {
-      var landscapeRoot = new postcss.atRule({ params: '(orientation: landscape)', name: 'media' });
-
-      landscapeRules.forEach(function(rule) {
-        landscapeRoot.append(rule);
-      });
-      css.append(landscapeRoot);
-    }
+    },
   };
-});
+};
+
+module.exports.postcss = true;
 
 function getUnit(prop, opts) {
   return prop.indexOf('font') === -1 ? opts.viewportUnit : opts.fontViewportUnit;
@@ -156,10 +160,6 @@ function createPxReplace(opts, viewportUnit, viewportSize) {
     var parsedVal = toFixed((pixels / viewportSize * 100), opts.unitPrecision);
     return parsedVal === 0 ? '0' : parsedVal + viewportUnit;
   };
-}
-
-function error(decl, message) {
-  throw decl.error(message, { plugin: 'postcss-px-to-viewport' });
 }
 
 function checkRegExpOrArray(options, optionName) {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "devDependencies": {
     "jest": "^25.4.0",
-    "postcss": ">=5.0.2"
+    "postcss": "^8.0.0"
   },
   "peerDependencies": {
-    "postcss": ">=5.0.2"
+    "postcss": "^8.0.0"
   }
 }


### PR DESCRIPTION
Some apis of `postcss5` have been deprecated, and will console following warning:

```bash
postcss-px-to-viewport: postcss.plugin was deprecated.
```

I upgraded it from `postcss5` to `postcss8`, and test cases are all passed.

The main modifications are to use `exports.default = creator` instead of `exports.default = postcss.plugins(name, creator)`, and remove `var postcss = require('postcss');` in `index.js`.