### PR TITLE
viewportWidth支持用户传入function，根据不同文件名设置不同的基准尺寸

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,10 @@ module.exports = postcss.plugin('postcss-px-to-viewport', function (options) {
     css.walkRules(function (rule) {
       // Add exclude option to ignore some files like 'node_modules'
       var file = rule.source && rule.source.input.file;
-
+      // Allow incoming functions,Set multiple viewportWidths
+      if(typeof options.viewportWidth === 'function'){
+        opts.viewportWidth = options.viewportWidth(file);
+      }
       if (opts.include && file) {
         if (Object.prototype.toString.call(opts.include) === '[object RegExp]') {
           if (!opts.include.test(file)) return;


### PR DESCRIPTION
有些ui库的设计尺寸可能不一样，这样可以通过文件名对不同的ui库做自定义设置。